### PR TITLE
This adds a partial to easily add media queries for responsive grids. 

### DIFF
--- a/_fg_breakpoint.scss
+++ b/_fg_breakpoint.scss
@@ -6,12 +6,12 @@
 
 @mixin _fg_breakpoint($_fg_media) {
   @if $_fg_media == small {
-    @media only screen and (min-width: $small) and (max-width: $medium){ @content; }
+    @media only screen and (min-width: $_fg_small) and (max-width: $_fg_medium){ @content; }
   }
   @else if $_fg_media == medium {
-    @media only screen and (min-width: $medium) and (max-width: $large) { @content; }
+    @media only screen and (min-width: $_fg_medium) and (max-width: $_fg_large) { @content; }
   }
   @else if $_fg_media == large {
-    @media only screen and (min-width: $large) { @content; }
+    @media only screen and (min-width: $_fg_large) { @content; }
   }
 }

--- a/_fg_breakpoint.scss
+++ b/_fg_breakpoint.scss
@@ -1,0 +1,17 @@
+
+//Override as required.
+  $_fg_small: 480px !default;
+  $_fg_medium: 720px !default;
+  $_fg_large: 1024px !default;
+
+@mixin _fg_breakpoint($_fg_media) {
+  @if $_fg_media == small {
+    @media only screen and (min-width: $small) and (max-width: $medium){ @content; }
+  }
+  @else if $_fg_media == medium {
+    @media only screen and (min-width: $medium) and (max-width: $large) { @content; }
+  }
+  @else if $_fg_media == large {
+    @media only screen and (min-width: $large) { @content; }
+  }
+}


### PR DESCRIPTION
The mixin takes keywords as parameter and sets accordingly the media queries. The breakpoints can be overriden. Here is a codepen: 

(http://codepen.io/SarafJayesh/pen/NbgZrQ) 