### PR TITLE
adds a conditional statement for padding on children

### DIFF
--- a/_fg_grid.scss
+++ b/_fg_grid.scss
@@ -36,9 +36,13 @@ $_fg_padding: 12 !default; // padding for column boxes. Set as desired, can over
     flex-wrap: wrap;
     margin-left: (-1 * $gutter) * 1px;
 
-  > * { padding: $padding * 1px;
-      margin-left: $gutter * 1px;
-      box-sizing: border-box; }
+  > * {
+    @if $padding != 0 {
+      padding: $padding * 1px;
+    }
+    margin-left: $gutter * 1px;
+    box-sizing: border-box;
+  }
 
   $calc_percent: (1/$cols) * 100%;
   $calc_gutter_allowance: $gutter * 1px;


### PR DESCRIPTION
Adds a conditional statement for the padding rule on children. 

### Problem:
```slim
.container
  .child1
  .child2
```
```sass
.container
  +_fg(1 2, 25, 0)

.child2
  padding: 20px
```
Simple example. I can nest the child styles under container in this example, but in a case of modular components, you'd style the child components separately to have flat css. In the example only `.child2` needs padding. The `+_fg()` mixin will output `.container > * {padding: 0px}`. That is 2 selectors and it'll override the single class selector `.child2 {padding: 20px}` style.

### Solution
Adding a simple conditional statement fixes this by not outputting the padding rule at all when it's `0`. 